### PR TITLE
Fix problem with adding items to database.

### DIFF
--- a/wynn/app/window.h
+++ b/wynn/app/window.h
@@ -134,6 +134,7 @@ protected:
 	QList<int> getSelectedDbaseTableIdxs();
 	void copyToAnotherDatabase(bool move);
 	void popDbaseLocked();
+    void addToDatabase(const QString &item, const QString &desc);
 
 	void setQuizControlsEnabled(bool arg);
 	DbEntry::QuizDirection curQuizType() const;

--- a/wynn/plugins/jp_cn/jp-cn_base.cpp
+++ b/wynn/plugins/jp_cn/jp-cn_base.cpp
@@ -74,12 +74,10 @@ JpCnPluginBase::JpCnPluginBase() : QObject(), DictionaryPlugin(),
 
 	QLOG("Setting up kanji details dialog");
 	kanjiUI_.setupUi(kanjiDialog_);
-	connect(kanjiUI_.detAddButton,  SIGNAL(clicked()), this, SLOT(kanjiAddClicked()));
-	connect(kanjiUI_.detCopyButton, SIGNAL(clicked()), this, SLOT(kanjiCopyClicked()));
+    connect(kanjiUI_.detCopyButton, SIGNAL(clicked()), this, SLOT(kanjiCopyClicked()));
 
 	QLOG("Setting up word details dialog");
 	wordUI_.setupUi(wordDialog_);
-	connect(wordUI_.detAddButton,  SIGNAL(clicked()), this, SLOT(wordAddClicked()));
 	connect(wordUI_.detCopyButton, SIGNAL(clicked()), this, SLOT(wordCopyClicked()));
 
 	QLOGDEC;
@@ -211,12 +209,13 @@ void JpCnPluginBase::preSetup(QWidget *parent, class QTSLogger *debugLog)
 	wordDialog_->setParent(parent, flags);
 
 	// connect signals to and from application
-	connect(this, SIGNAL(searchStart()),                     app_, SLOT(slot_dict_searchStart()));
-	connect(this, SIGNAL(searchDone()),                      app_, SLOT(slot_dict_searchDone()));
-	connect(this, SIGNAL(message(const QString &)),          app_, SLOT(slot_updateSetupMsg(const QString &)));
-
-	connect(parent, SIGNAL(dictColumnResized(int, int, int, int)), this,   SLOT(columnResize(int, int, int, int)));
-	connect(this,   SIGNAL(columnWidthsNotify(const QList<int>&)), parent, SLOT(slot_dict_resizeColumns(const QList<int>&)));
+    connect(this,                  SIGNAL(searchStart()),                         parent, SLOT(slot_dict_searchStart()));
+    connect(this,                  SIGNAL(searchDone()),                          parent, SLOT(slot_dict_searchDone()));
+    connect(this,                  SIGNAL(message(const QString &)),              parent, SLOT(slot_updateSetupMsg(const QString &)));
+    connect(this,                  SIGNAL(columnWidthsNotify(const QList<int>&)), parent, SLOT(slot_dict_resizeColumns(const QList<int>&)));
+    connect(parent,                SIGNAL(dictColumnResized(int, int, int, int)), this,   SLOT(columnResize(int, int, int, int)));
+    connect(kanjiUI_.detAddButton, SIGNAL(clicked()),                             parent, SLOT(slot_dict_toDbaseClicked()));
+    connect(wordUI_.detAddButton,  SIGNAL(clicked()),                             parent, SLOT(slot_dict_toDbaseClicked()));
 
     QLOGDEC;
 }
@@ -549,14 +548,6 @@ void JpCnPluginBase::wordSearchButtonClicked()
 	emit searchDone();
 
 	QLOGDEC;
-}
-
-void JpCnPluginBase::kanjiAddClicked()
-{
-}
-
-void JpCnPluginBase::wordAddClicked()
-{
 }
 
 void JpCnPluginBase::kanjiCopyClicked()

--- a/wynn/plugins/jp_cn/jp-cn_base.h
+++ b/wynn/plugins/jp_cn/jp-cn_base.h
@@ -94,8 +94,6 @@ private slots:
 	void charSearchButtonClicked();
 	void wordSearchButtonClicked();
 
-	void kanjiAddClicked();
-	void wordAddClicked();
 	void kanjiCopyClicked();
 	void wordCopyClicked();
 	


### PR DESCRIPTION
Caused by the clicked() signals of the relevant Store buttons on the details dialogs being connected to non-implemented slots in JpCnPluginBase. Solved by reconnecting to MainForm::slot_dict_toDbaseClicked() instead, it works by extracting the current item from the table but since the table item has to exist and be selected while the details dialogs are popped, it doesn't make any difference and saves the effort of scraping the item/desc data from the details dialog contents.