### PR TITLE
libixpdict: Fix problem with empty dictionary load

### DIFF
--- a/libixpdict/include/dictionary_store.h
+++ b/libixpdict/include/dictionary_store.h
@@ -39,7 +39,7 @@ template <typename T> void Dictionary<T>::loadData(const QString &path)
 	}
 	QDataStream in(&f);
 	in >> entries_;
-	if (in.status() != QDataStream::Ok) 
+	if (in.status() != QDataStream::Ok || entries_.empty()) 
 	{
 		//QLOGX("Error reading dictionary file, status: " << in.status());
 		error_ = true;


### PR DESCRIPTION
No error was reported when dictionary was loaded successfully, albeit with empty contents. Also, submitted deployable version of German dictionary to repo instead of an empty one.